### PR TITLE
Touch parameters.yml

### DIFF
--- a/lib/sumodev_deploy.rb
+++ b/lib/sumodev_deploy.rb
@@ -65,6 +65,7 @@ Capistrano::Configuration.instance.load do
   role(:db, :primary => true) { db_server }
 
   after 'deploy', 'deploy:cleanup', 'sumodev:errbit:after_deploy'
+  after 'forkcms:link_configs', 'cache:touch_parameters'
 
   namespace :sumodev do
     namespace :setup do

--- a/lib/sumodev_deploy.rb
+++ b/lib/sumodev_deploy.rb
@@ -1,4 +1,5 @@
 Capistrano::Configuration.instance.load do
+  require 'sumodev_deploy/tasks/cache'
   require 'sumodev_deploy/tasks/db'
   require 'sumodev_deploy/tasks/errbit'
   require 'sumodev_deploy/tasks/files'

--- a/lib/sumodev_deploy/tasks/cache.rb
+++ b/lib/sumodev_deploy/tasks/cache.rb
@@ -1,0 +1,9 @@
+Capistrano::Configuration.instance.load do
+  namespace :cache do
+    desc "touch the parameters.yml file"
+    task :touch_parameters do
+      run "if [ -f #{shared_path}/config/library/globals.php ]; then touch #{shared_path}/config/library/globals.php; fi"
+      run "if [ -f #{shared_path}/config/parameters.yml ]; then touch #{shared_path}/config/parameters.yml; fi"
+    end
+  end
+end


### PR DESCRIPTION
Touch parameters.yml (or globals.php) on deploy.

This is needed as we use the modification date of the this file to calculate the timestamp that will be appended to certain JS or CSS-files.

I added this in the sumodev_deploy and not in [sumocoders/forkcms_deploy](https://github.com/sumocoders/forkcms_deploy) as I don't want create the impression that bundle is still maintained.