### PR TITLE
files:put & files:get on custom SSH-port

### DIFF
--- a/lib/sumodev_deploy/tasks/files.rb
+++ b/lib/sumodev_deploy/tasks/files.rb
@@ -39,10 +39,14 @@ Capistrano::Configuration.instance.load do
       task :get, :roles => :app do
         path = find_folder_in_parents('src/Frontend/Files')
         if !path
-          abort "No src/Frontend/Files folder found in this or upper folders. Are you sure you're in a Fork project?"
-        else
-          rsync :down, shared_files_path, path, :once => true
+          path = find_folder_in_parents('frontend/files')
+
+          if !path
+            abort "No src/Frontend/Files or frontend/files folder found in this or upper folders. Are you sure you're in a Fork project?"
+           end
         end
+
+        rsync :down, shared_files_path, path, :once => true
       end
 
       desc "Sync your local files to the remote server"
@@ -53,10 +57,14 @@ Capistrano::Configuration.instance.load do
         # check if folder exists
         path = find_folder_in_parents('src/Frontend/Files')
         if !path
-          abort "No src/Frontend/Files folder found in this or upper folders. Are you sure you're in a Fork project?"
-        else
-          rsync :up, "#{path}/", shared_files_path
+            path = find_folder_in_parents('frontend/files')
+
+            if !path
+                abort "No src/Frontend/Files or frontend/files folder found in this or upper folders. Are you sure you're in a Fork project?"
+            end
         end
+
+        rsync :up, "#{path}/", shared_files_path
       end
     end
   end

--- a/lib/sumodev_deploy/tasks/files.rb
+++ b/lib/sumodev_deploy/tasks/files.rb
@@ -19,7 +19,12 @@ Capistrano::Configuration.instance.load do
 
         servers.each do |server|
           host_definition = "#{server.user || user}@#{server.host}"
-          host_definition << ":#{server.port}" if server.port && server.port != 22
+          if server.port && server.port != 22
+            host_definition << ":#{server.port}"
+          elsif ssh_options[:port] && ssh_options[:port] != 22
+            host_definition = " -e 'ssh -p #{ssh_options[:port]}' #{host_definition}"
+          end
+
 
           case direction
           when :down


### PR DESCRIPTION
This will allow us to use `sumodev:files:put` and `sumodev:files:get` on servers that are only reachable on a custom port for SSH.

This fixes https://app.activecollab.com/108877/projects/45/tasks/81693?back_path=my_work